### PR TITLE
Replace grub with limine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.iso
 /iso/
 /sysroot/
+/limine/
 
 # Prerequisites
 *.d

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Some interesting resources that influenced the project's philosophy:
 #### Requisites
 - i686-elf cross compiler from [here](https://github.com/fs-os/cross-compiler).
 - [nasm](https://nasm.us) for compiling the assembly used in the project.
-- [grub](https://www.gnu.org/software/grub) and [xorriso](https://www.gnu.org/software/xorriso) for creating the bootable image.
+- The [limine](https://github.com/limine-bootloader/limine) dependencies, including [xorriso](https://www.gnu.org/software/xorriso) for creating the bootable image.
 - (Optional) [qemu](https://www.qemu.org) for testing the ISO on a VM.
 
 #### Building
@@ -55,3 +55,4 @@ See [todo.md](TODO.md).
 
 ### Credits
 - [OSDev wiki](https://wiki.osdev.org)
+- [The limine bootloader](https://github.com/limine-bootloader/limine)

--- a/cfg/grub.cfg
+++ b/cfg/grub.cfg
@@ -1,4 +1,0 @@
-
-menuentry "fs-os (GITHASH)" {
-    multiboot /boot/fs-os.bin
-}

--- a/cfg/limine.cfg
+++ b/cfg/limine.cfg
@@ -1,0 +1,13 @@
+
+# Timeout in seconds that Limine will use before automatically booting.
+TIMEOUT=5
+
+# The entry name that will be displayed in the boot menu
+:fs-os (GITHASH)
+    COMMENT=Free and Simple Operating System
+
+    # Change the protocol line depending on the used protocol.
+    PROTOCOL=multiboot
+
+    # Path to the kernel to boot. boot:/// represents the partition on which limine.cfg is located.
+    KERNEL_PATH=boot:///boot/fs-os.bin


### PR DESCRIPTION
### Changes
- Replace grub bootloader with [limine](https://github.com/limine-bootloader/limine).

### Notes
- Boot protocol is still [multiboot1](https://wiki.osdev.org/Multiboot), not [limine](https://github.com/limine-bootloader/limine/blob/trunk/PROTOCOL.md)'s boot protocol.