### PR TITLE
Add align parameter to `heap_alloc`, add `fxsave` and `fxrstor` for multitasking

### DIFF
--- a/src/apps/sh/commands.h
+++ b/src/apps/sh/commands.h
@@ -548,9 +548,9 @@ static int cmd_test_multitask() {
      *
      * For more information, call dump_task_list() after creating the tasks.
      */
-    Ctx* task2 = mt_newtask("task2", (void*)multitask_test2);
-    Ctx* task1 = mt_newtask("task1", (void*)multitask_test1);
-    Ctx* task0 = mt_newtask("task0", (void*)multitask_test0);
+    Ctx* task2 = mt_newtask("task2", multitask_test2);
+    Ctx* task1 = mt_newtask("task1", multitask_test1);
+    Ctx* task0 = mt_newtask("task0", multitask_test0);
 
     for (int i = 0; i <= 5; i++) {
         printf("%s: %d\n", mt_gettask()->name, i);

--- a/src/kernel/heap.c
+++ b/src/kernel/heap.c
@@ -66,9 +66,13 @@ void* heap_alloc(size_t sz, size_t align) {
             /* Update current 'blk->sz' since we moved the header */
             blk->sz -= sz_pad;
 
-            /* Also update the size and new location in the previous item */
+            /* Also update the size and new location in the previous item, and
+             * the next one if there is one */
             blk->prev->next = blk;
             blk->prev->sz += sz_pad;
+
+            if (blk->next != NULL)
+                blk->next->prev = blk;
         }
 
         /* Location of the new block we will add after the size we are

--- a/src/kernel/heap.c
+++ b/src/kernel/heap.c
@@ -54,9 +54,14 @@ void* heap_alloc(size_t sz, size_t align) {
              * block, add padding to size of last block */
             blk->prev->sz += sz_pad;
 
-            /** @todo Move current 'blk' since we updated the prev's sz */
-            /** @todo Update current 'blk->sz' since we moved the header
-             * (subtract pad we added to prevs sz) */
+            /* Move current 'blk' since we updated the prev's sz */
+            Block tmp = *blk;
+            memset(blk, 0, sizeof(Block));
+            blk  = (Block*)((uint32_t)blk + sz_pad);
+            *blk = tmp;
+
+            /* Update current 'blk->sz' since we moved the header */
+            blk->sz -= sz_pad;
         }
 
         /* Location of the new block we will add after the size we are

--- a/src/kernel/heap.c
+++ b/src/kernel/heap.c
@@ -10,6 +10,8 @@
  */
 #define HEADER_TO_PTR(blk) ((void*)((uint32_t)blk + sizeof(Block)))
 
+/** @todo FREE/BUSY enum instead of 1/0 */
+
 Block* blk_cursor = (Block*)HEAP_START;
 
 void heap_init(void) {
@@ -68,8 +70,8 @@ void* heap_alloc(size_t sz, size_t align) {
 
             /* Also update the size and new location in the previous item, and
              * the next one if there is one */
-            blk->prev->next = blk;
             blk->prev->sz += sz_pad;
+            blk->prev->next = blk;
 
             if (blk->next != NULL)
                 blk->next->prev = blk;

--- a/src/kernel/heap.c
+++ b/src/kernel/heap.c
@@ -63,6 +63,10 @@ void* heap_alloc(size_t sz, size_t align) {
 
             /* Update current 'blk->sz' since we moved the header */
             blk->sz -= sz_pad;
+
+            /** @todo Check if the updated size is still enough to hold what was
+             * requested
+             * (If not, continue;) */
         }
 
         /* Location of the new block we will add after the size we are

--- a/src/kernel/heap.c
+++ b/src/kernel/heap.c
@@ -61,6 +61,9 @@ void* heap_alloc(size_t sz, size_t align) {
             blk  = (Block*)((uint32_t)blk + sz_pad);
             *blk = tmp;
 
+            /* Also update the location of the previous item */
+            blk->prev->next = blk;
+
             /* Update current 'blk->sz' since we moved the header */
             blk->sz -= sz_pad;
 

--- a/src/kernel/heap.c
+++ b/src/kernel/heap.c
@@ -2,6 +2,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h> /* memset */
 #include <kernel/heap.h>
 
 /**

--- a/src/kernel/heap.c
+++ b/src/kernel/heap.c
@@ -155,6 +155,9 @@ void heap_free(void* ptr) {
             blk->next->prev = blk->prev;
 
         blk->prev->next = blk->next;
+
+        /* Once we are done merging with prev, we update the blk ptr */
+        blk = blk->prev;
     }
 
     /* If the next block is being used, just set this one free */

--- a/src/kernel/heap.c
+++ b/src/kernel/heap.c
@@ -51,25 +51,24 @@ void* heap_alloc(size_t sz, size_t align) {
             /* Once we know we need padding, update var to know how much */
             sz_pad = align - sz_pad;
 
-            /* If the start of the data is not algined and this is not the first
-             * block, add padding to size of last block */
-            blk->prev->sz += sz_pad;
+            /* Check if the updated size is still enough to hold what was
+             * requested */
+            if (blk->sz - sz_pad < sz)
+                continue;
 
-            /* Move current 'blk' since we updated the prev's sz */
+            /* If the start of the data is not algined and this is not the first
+             * block, move current 'blk' */
             Block tmp = *blk;
             memset(blk, 0, sizeof(Block));
             blk  = (Block*)((uint32_t)blk + sz_pad);
             *blk = tmp;
 
-            /* Also update the location of the previous item */
-            blk->prev->next = blk;
-
             /* Update current 'blk->sz' since we moved the header */
             blk->sz -= sz_pad;
 
-            /** @todo Check if the updated size is still enough to hold what was
-             * requested
-             * (If not, continue;) */
+            /* Also update the size and new location in the previous item */
+            blk->prev->next = blk;
+            blk->prev->sz += sz_pad;
         }
 
         /* Location of the new block we will add after the size we are

--- a/src/kernel/include/kernel/heap.h
+++ b/src/kernel/include/kernel/heap.h
@@ -16,8 +16,8 @@ typedef struct Block Block;
  * @details The block ptr should point to (header_ptr + sizeof(Block))
  */
 struct Block {
-    Block* prev; /** @brief Pointer to prev header. Start of heap means NULL */
-    Block* next; /** @brief Pointer to next header. End of heap means NULL */
+    Block* prev; /** @brief Pointer to prev header. NULL means start of heap */
+    Block* next; /** @brief Pointer to next header. NULL means end of heap */
     uint32_t sz; /** @brief Block size in bytes */
     bool free;   /** @brief True if the block is not being used */
 };
@@ -35,12 +35,13 @@ extern Block* blk_cursor;
 void heap_init(void);
 
 /**
- * @brief Allocate \p sz bytes of memory from the heap and return the address
- * @details Size will be padded to 8 bytes.
+ * @brief Allocate `sz` bytes of memory from the heap and return the address
+ * @details Returned pointer will be padded/aligned to the parameter.
  * @param[in] sz Size in bytes to allocate
- * @return Pointer to the allocated block of memory
+ * @param[in] align Number for aligning the start of the returned pointer
+ * @return Pointer to the allocated (aligned) block of memory
  */
-void* heap_alloc(size_t sz);
+void* heap_alloc(size_t sz, size_t align);
 
 /**
  * @brief Free a previously allocated ptr.

--- a/src/kernel/include/kernel/multitask.h
+++ b/src/kernel/include/kernel/multitask.h
@@ -131,6 +131,6 @@ Ctx* mt_gettask(void);
  * @brief Print the list of tasks starting with the current one.
  * @details Defined in src/kernel/multitask.c
  */
-void dump_task_list(void);
+void mt_dump_tasks(void);
 
 #endif /* _KERNEL_MULTITASK_H */

--- a/src/kernel/include/kernel/multitask.h
+++ b/src/kernel/include/kernel/multitask.h
@@ -11,12 +11,13 @@ typedef struct Ctx Ctx;
  * @details We could add more stuff like parent task and priority
  */
 struct Ctx {
-    Ctx* next;      /**< @brief Pointer to next task */
-    Ctx* prev;      /**< @brief Pointer to next task */
-    uint32_t stack; /**< @brief Pointer to the allocated stack for the task */
-    uint32_t esp;   /**< @brief Stack top */
-    uint32_t cr3;   /**< @brief cr3 register (page directory) */
-    char* name;     /**< @brief Task name */
+    Ctx* next;       /**< @brief Pointer to next task */
+    Ctx* prev;       /**< @brief Pointer to next task */
+    uint32_t stack;  /**< @brief Pointer to the allocated stack for the task */
+    uint32_t esp;    /**< @brief Stack top */
+    uint32_t cr3;    /**< @brief cr3 register (page directory) */
+    uint32_t fxdata; /**< @brief 512 bytes needed for fxsave to store FPU/SSE */
+    char* name;      /**< @brief Task name */
 };
 
 typedef struct tss_t Tss;

--- a/src/kernel/multitask.c
+++ b/src/kernel/multitask.c
@@ -3,13 +3,14 @@
 #include <stdio.h>
 #include <kernel/multitask.h>
 
+/** @todo Print fxdata */
 void dump_task_list(void) {
     puts("Dumping task list:");
 
     /* 0 will be the current one, not the first task we created */
     int i = 0;
 
-    Ctx* const first_ctx = mt_current_task;
+    Ctx* first_ctx = mt_current_task;
 
     /* We at least want to print one */
     printf("[%d] %s | prev: %p | next: %p | stack: 0x%lX | esp: 0x%lX | cr3: "
@@ -17,7 +18,7 @@ void dump_task_list(void) {
            i++, first_ctx->name, first_ctx->prev, first_ctx->next,
            first_ctx->stack, first_ctx->esp, first_ctx->cr3);
 
-    for (Ctx* cur_ctx = mt_current_task; cur_ctx->next != first_ctx;
+    for (Ctx* cur_ctx = first_ctx->next; cur_ctx != first_ctx;
          cur_ctx      = cur_ctx->next, i++) {
         printf("[%d] %s | prev: %p | next: %p | stack: 0x%lX | esp: 0x%lX | "
                "cr3: 0x%lX\n",
@@ -25,4 +26,3 @@ void dump_task_list(void) {
                cur_ctx->esp, cur_ctx->cr3);
     }
 }
-

--- a/src/kernel/multitask.c
+++ b/src/kernel/multitask.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <kernel/multitask.h>
 
-void dump_task_list(void) {
+void mt_dump_tasks(void) {
     puts("Dumping task list:");
 
     /* 0 will be the current one, not the first task we created */

--- a/src/kernel/multitask.c
+++ b/src/kernel/multitask.c
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <kernel/multitask.h>
 
-/** @todo Print fxdata */
 void dump_task_list(void) {
     puts("Dumping task list:");
 
@@ -13,16 +12,16 @@ void dump_task_list(void) {
     Ctx* first_ctx = mt_current_task;
 
     /* We at least want to print one */
-    printf("[%d] %s | prev: %p | next: %p | stack: 0x%lX | esp: 0x%lX | cr3: "
-           "0x%lX\n",
-           i++, first_ctx->name, first_ctx->prev, first_ctx->next,
-           first_ctx->stack, first_ctx->esp, first_ctx->cr3);
+    printf("[%d] %s | ctx: %p | prev: %p | next: %p | stack: 0x%lX | esp: "
+           "0x%lX | cr3: 0x%lX | fxdata: 0x%lX\n",
+           i++, first_ctx->name, first_ctx, first_ctx->prev, first_ctx->next,
+           first_ctx->stack, first_ctx->esp, first_ctx->cr3, first_ctx->fxdata);
 
     for (Ctx* cur_ctx = first_ctx->next; cur_ctx != first_ctx;
          cur_ctx      = cur_ctx->next, i++) {
-        printf("[%d] %s | prev: %p | next: %p | stack: 0x%lX | esp: 0x%lX | "
-               "cr3: 0x%lX\n",
-               i, cur_ctx->name, cur_ctx->prev, cur_ctx->next, cur_ctx->stack,
-               cur_ctx->esp, cur_ctx->cr3);
+        printf("[%d] %s | ctx: %p | prev: %p | next: %p | stack: 0x%lX | esp: "
+               "0x%lX | cr3: 0x%lX | fxdata: 0x%lX\n",
+               i, cur_ctx->name, cur_ctx, cur_ctx->prev, cur_ctx->next,
+               cur_ctx->stack, cur_ctx->esp, cur_ctx->cr3, cur_ctx->fxdata);
     }
 }

--- a/src/kernel/structs.asm
+++ b/src/kernel/structs.asm
@@ -71,6 +71,8 @@ struc ctx_t
     .esp:       resd 1          ; Top of the current task's stack
     .cr3:       resd 1          ; cr3 register for the current task (virtual
                                 ; address space/page directory)
+    .fxdata:    resd 1          ; 512 bytes needed for fxsave to store fpu/sse
+                                ; registers
     .name:      resd 1          ; char* to the task name
 endstruc
 

--- a/src/kernel/structs.asm
+++ b/src/kernel/structs.asm
@@ -67,12 +67,12 @@ endstruc
 struc ctx_t
     .next:      resd 1          ; Pointer to next task
     .prev:      resd 1          ; Pointer to previous task
-    .stack:     resd 1          ; Address of the allocated stack. Used for free()
+    .stack:     resd 1          ; Address of the allocated stack for freeing
     .esp:       resd 1          ; Top of the current task's stack
     .cr3:       resd 1          ; cr3 register for the current task (virtual
                                 ; address space/page directory)
     .fxdata:    resd 1          ; 512 bytes needed for fxsave to store fpu/sse
-                                ; registers
+                                ; registers. Aligned to 16 bytes.
     .name:      resd 1          ; char* to the task name
 endstruc
 

--- a/src/libk/stdlib.c
+++ b/src/libk/stdlib.c
@@ -161,7 +161,8 @@ void abort(void) {
 }
 
 void* malloc(size_t sz) {
-    return heap_alloc(sz);
+    /* Aligned to 8 bytes */
+    return heap_alloc(sz, 8);
 }
 
 void* calloc(size_t item_n, size_t item_sz) {

--- a/src/libk/string.c
+++ b/src/libk/string.c
@@ -1,4 +1,5 @@
 
+#include <stdint.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -35,8 +36,8 @@ char* strrev(char* str) {
 }
 
 int memcmp(const void* a, const void* b, size_t sz) {
-    unsigned char* ap = (unsigned char*)a;
-    unsigned char* bp = (unsigned char*)b;
+    uint8_t* ap = (uint8_t*)a;
+    uint8_t* bp = (uint8_t*)b;
 
     while (sz-- > 0) {
         if (*ap < *bp)
@@ -52,17 +53,17 @@ int memcmp(const void* a, const void* b, size_t sz) {
 }
 
 void* memset(void* ptr, int val, size_t sz) {
-    unsigned char* p = (unsigned char*)ptr;
+    uint8_t* p = (uint8_t*)ptr;
 
     while (sz-- > 0)
-        *p++ = (unsigned char)val;
+        *p++ = (uint8_t)val;
 
     return ptr;
 }
 
 void* memcpy(void* restrict dst, const void* restrict src, size_t sz) {
-    unsigned char* dp = (unsigned char*)dst;
-    unsigned char* sp = (unsigned char*)src;
+    uint8_t* dp = (uint8_t*)dst;
+    uint8_t* sp = (uint8_t*)src;
 
     while (sz-- > 0)
         *dp++ = *sp++;


### PR DESCRIPTION
Changes:
- The `heap_alloc` function now aligns the allocated memory to the specified parameter.
- Fix bug in `heap_free` not updating the local `blk` pointer after merging with previous block, causing the `blk_cursor` to update incorrectly.
- Fix bug in `mt_newtask` writing the entry point of the task right after the allocated stack instead of at the last 4 bytes (bottom of the stack). See: #12.
- Add `.fxdata` to `Ctx` struct, reserve 512 bytes for `first_fxdata` and allocate 512 bytes for each created task.
- Call `fxsave` and `fxrstor` in `mt_switch`.
- Free `ctx_t.fxdata` in `mt_endtask`.
- Replace calls to `malloc` inside `multitask.asm` with calls to `heap_alloc`.
- Update stdlib's `malloc` wrapper with extra align parameter for `heap_alloc`.
- Remove `print_header_id` inline function, improve `heap_dump_headers` output format.
- Rename `dump_task_list` to `mt_dump_tasks`.
- Add new members of `Ctx` struct to `mt_dump_tasks`.
- Minor changes for readability:
  - Add member names on `Block` declarations.
  - Use `HEADER_TO_PTR(blk)` macro when possible.
  - Use `true` and `false` instead of 1 and 0 when assigning `Block.free`.
  - Added TODO comments.
  - Improve some comments.


> **Note:**
> The task context struct is called `Ctx` in C and `ctx_t` in assembly. This might change soon.